### PR TITLE
Always save CSV with UTF-8 encoding

### DIFF
--- a/.github/workflows/endtoend.yaml
+++ b/.github/workflows/endtoend.yaml
@@ -25,7 +25,8 @@ jobs:
       - name: Install fa-scrapper
         run: poetry install
       - name: Install csv-diff
-        run: python3 -m pip install csv-diff
+        # Install csv-diff with https://github.com/simonw/csv-diff/pull/19
+        run: python3 -m pip install git+https://github.com/mikecoop83/csv-diff@c3d32f758343a2ba3737d612e6e906fd9d77322b
       - name: Run fa-scrapper
         env:
           TEST_ACCOUNT_ID: ${{ secrets.TEST_ACCOUNT_ID }}
@@ -35,5 +36,5 @@ jobs:
       - name: Check output
         env:
           FA_LANG: ${{ matrix.lang }}
-        run: csv-diff output.csv testdata/expected-${FA_LANG}.csv
+        run: csv-diff --encoding "utf-8" output.csv testdata/expected-${FA_LANG}.csv
         shell: bash

--- a/fa_scraper/fa_scraper.py
+++ b/fa_scraper/fa_scraper.py
@@ -211,7 +211,9 @@ def save_to_csv(
 ):
     """Saves films in a csv file"""
 
-    with open(filename, "w", newline="") as csvfile:
+    # Set to UTF-8 to work around Windows error
+    # "'charmap' codec can't encode character".
+    with open(filename, "w", encoding="utf-8", newline="") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         writer.writeheader()
         for d in dicts:

--- a/testdata/expected-en.csv
+++ b/testdata/expected-en.csv
@@ -1,4 +1,5 @@
 Title,Year,Directors,WatchedDate,Rating,Rating10
+Attack on Titan: Chronicle,2020,"Masashi Koizuka, Tetsurō Araki",2022-01-03,4.0,8
 Full Metal Jacket,1987,Stanley Kubrick,2021-11-10,2.0,4
 The Lion King,1994,"Rob Minkoff, Roger Allers",2021-11-10,3.5,7
 Mad Max: Fury Road,2015,George Miller,2021-11-10,5.0,10

--- a/testdata/expected-es.csv
+++ b/testdata/expected-es.csv
@@ -1,4 +1,5 @@
 Title,Year,Directors,WatchedDate,Rating,Rating10
+Shingeki no Kyojin: Chronicle,2020,"Masashi Koizuka, Tetsurō Araki",2022-01-04,4.0,8
 La chaqueta metálica,1987,Stanley Kubrick,2021-11-11,2.0,4
 El rey león,1994,"Rob Minkoff, Roger Allers",2021-11-11,3.5,7
 Mad Max: Furia en la carretera,2015,George Miller,2021-11-11,5.0,10


### PR DESCRIPTION
Fixes #66 by:
- Updating test output with new film whose director has a character that can't be encoded in Python's default encoding for Windows (CP-1252)
- Setting encoding to UTF-8 explicitly when `open`ing the csv
- Updating `csv-diff` to use simonw/csv-diff#19 so that we can set the encoding explicitly when comparing on Windows