### PR TITLE
Solve issues after new page format + fix list-only scrapper

### DIFF
--- a/fa_scraper/fa_scraper.py
+++ b/fa_scraper/fa_scraper.py
@@ -132,15 +132,13 @@ def get_profile_data(
 ) -> Iterator[Mapping[str, Any]]:
     """Yields films rated by user given user id"""
 
-    FA = (FA_ROOT_URL + "userratings.php?user_id={id}&p={{}}&orderby=rating-date&chv=list").format(
-        lang=lang, id=user_id
-    )
+    FA = (
+        FA_ROOT_URL + "userratings.php?user_id={id}&p={{}}&orderby=rating-date&chv=list"
+    ).format(lang=lang, id=user_id)
 
     for page in pages_from(FA):
         try:
-            ratings_on_a_date = page.contents.find_all(
-                class_=["fa-content-card"]
-            )
+            ratings_on_a_date = page.contents.find_all(class_=["fa-content-card"])
             cur_date = None
 
             for ratings in ratings_on_a_date:
@@ -153,12 +151,16 @@ def get_profile_data(
                         title_name = title.string.strip()
                         title_type = tag.find_all(class_="types-wrapper")
                         if title_type and should_skip_type(
-                                title_type[0].find_all(class_="type")[0].string.strip(), lang, ignore_list
+                            title_type[0].find_all(class_="type")[0].string.strip(),
+                            lang,
+                            ignore_list,
                         ):
                             print(
                                 SKIP_TITLE_TEMPLATE.format(
                                     title=title_name,
-                                    title_type=title_type[0].find_all(class_="type")[0].string.strip(),
+                                    title_type=title_type[0]
+                                    .find_all(class_="type")[0]
+                                    .string.strip(),
                                 )
                             )
                             continue
@@ -173,9 +175,13 @@ def get_profile_data(
                             ),
                             "Directors": get_directors(tag),
                             "WatchedDate": cur_date,
-                            "Rating": int(tag.find_all(class_="fa-user-rat-box")[0].string)
+                            "Rating": int(
+                                tag.find_all(class_="fa-user-rat-box")[0].string
+                            )
                             / 2,
-                            "Rating10": tag.find_all(class_="fa-user-rat-box")[0].string.strip(),
+                            "Rating10": tag.find_all(class_="fa-user-rat-box")[
+                                0
+                            ].string.strip(),
                         }
                     except:
                         print(TITLE_ERROR_TEMPLATE.format(title=title.string.strip()))

--- a/fa_scraper/fa_scraper.py
+++ b/fa_scraper/fa_scraper.py
@@ -219,7 +219,8 @@ def get_list_data(
                     yield {
                         "Title": title_name,
                         "Year": int(
-                            tag.find_all(class_="d-flex")[0]
+                            tag.find_all(class_="fa-card")[0]
+                            .find_all(class_="d-flex")[0]
                             .find_all(class_="mc-year")[0]
                             .string.strip()
                         ),


### PR DESCRIPTION
I discovered the code had stopped working because the first `d-flex` class within the `movie-wrapper` section for a specific movie not always contains the year.

Testing:

I've been able to run the code successfully:

```
~/src/fa-scraper on  main! ⌚ 11:43:28
$ poetry run fa-scraper --csv putopeliculon.csv --list 1010 283382
The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.
Page 5. Download complete!
```

Also when checked the output file it looks as expected:

```
Title,Year,Directors
Tamala 2010: A Punk Cat in Space,2002,Tol
Trash Humpers,2009,Harmony Korine
Threads,1984,Mick Jackson
Pure Blood,1982,Luis Ospina
Scum,1979,Alan Clarke
Bulworth,1998,Warren Beatty
Possession,1981,Andrzej Zulawski
Void,1995,Daniel Calparsoro
I Am Cuba,1964,Mikhail Kalatozov
"The Devil, Probably",1977,Robert Bresson
Cargo 200,2007,Aleksei Balabanov
Pharaoh,1966,Jerzy Kawalerowicz
Deerskin,2019,Quentin Dupieux
Inspiration,1949,Karel Zeman
Our Beloved Month of August,2008,Miguel Gomes
Blacula,1972,William Crain
Esa sensación,2016,"Juan Cavestany, Julián Génisson, Pablo Hernando"
Maravillas,1980,Manuel Gutiérrez Aragón
Girls in Uniform,1931,"Leontine Sagan, Carl Froelich"
```
